### PR TITLE
Bugfix/long comments

### DIFF
--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -728,8 +728,15 @@ fn decode_type_info_by_name(data: &[u8]) -> Result<Type> {
         let name = String::from_utf8_lossy(&buf[..len_name]).into_owned();
         ptr.read_exact(&mut buf[..len_type + 1]).ctx(ctx)?;
         let type_name = String::from_utf8_lossy(&buf[..len_type]).into_owned();
-        ptr.read_exact(&mut buf[..len_comment + 1]).ctx(ctx)?;
-        let comment = String::from_utf8_lossy(&buf[..len_comment]).into_owned();
+        
+        let comment = if len_comment + 1 > buf.len() {
+            let mut comment_buf = vec![0; len_comment + 1];
+            ptr.read_exact(&mut comment_buf).ctx(ctx)?;
+            String::from_utf8_lossy(&comment_buf[..len_comment]).into_owned()
+        } else {
+            ptr.read_exact(&mut buf[..len_comment + 1]).ctx(ctx)?;
+            String::from_utf8_lossy(&buf[..len_comment]).into_owned()
+        };
 
         let mut array = vec![];
         for _ in 0..array_dim {

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -723,8 +723,20 @@ fn decode_type_info_by_name(data: &[u8]) -> Result<Type> {
         let name = String::from_utf8_lossy(&buf[..len_name]).into_owned();
         ptr.read_exact(&mut buf[..len_type + 1]).ctx(ctx)?;
         let type_name = String::from_utf8_lossy(&buf[..len_type]).into_owned();
-        ptr.read_exact(&mut buf[..len_comment + 1]).ctx(ctx)?;
-        let comment = String::from_utf8_lossy(&buf[..len_comment]).into_owned();
+        
+        let comment = {
+            let bytes = if len_comment + 1 > buf.len() {
+                 // make a new buffer to prevent it overflowing on really big comments if needed
+                let mut comment_buf = vec![0; len_comment + 1];
+                ptr.read_exact(&mut comment_buf).ctx(ctx)?;
+                comment_buf
+            } else {
+                ptr.read_exact(&mut buf[..len_comment + 1]).ctx(ctx)?;
+                buf[..len_comment + 1].to_vec()
+            };
+
+            String::from_utf8_lossy(&bytes[..len_comment]).into_owned()
+        };
 
         let mut array = vec![];
         for _ in 0..array_dim {

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -578,9 +578,14 @@ pub fn decode_symbol_info(symbol_data: Vec<u8>, type_data: Vec<u8>) -> Result<(V
         let name = String::from_utf8_lossy(&buf[..len_name]).into_owned();
         ptr.read_exact(&mut buf[..len_type + 1]).ctx(ctx)?;
         let type_name = String::from_utf8_lossy(&buf[..len_type]).into_owned();
-        ptr.read_exact(&mut buf[..len_comment + 1]).ctx(ctx)?;
-        let comment = String::from_utf8_lossy(&buf[..len_comment]).into_owned();
-
+        let comment = if len_comment + 1 > buf.len() {
+            let mut comment_buf = vec![0; len_comment + 1];
+            ptr.read_exact(&mut comment_buf).ctx(ctx)?;
+            String::from_utf8_lossy(&comment_buf[..len_comment]).into_owned()
+        } else {
+            ptr.read_exact(&mut buf[..len_comment + 1]).ctx(ctx)?;
+            String::from_utf8_lossy(&buf[..len_comment]).into_owned()
+        };
         let mut array = vec![];
         for _ in 0..array_dim {
             let lower = ptr.read_i32::<LE>().ctx(ctx)?;
@@ -723,20 +728,8 @@ fn decode_type_info_by_name(data: &[u8]) -> Result<Type> {
         let name = String::from_utf8_lossy(&buf[..len_name]).into_owned();
         ptr.read_exact(&mut buf[..len_type + 1]).ctx(ctx)?;
         let type_name = String::from_utf8_lossy(&buf[..len_type]).into_owned();
-        
-        let comment = {
-            let bytes = if len_comment + 1 > buf.len() {
-                 // make a new buffer to prevent it overflowing on really big comments if needed
-                let mut comment_buf = vec![0; len_comment + 1];
-                ptr.read_exact(&mut comment_buf).ctx(ctx)?;
-                comment_buf
-            } else {
-                ptr.read_exact(&mut buf[..len_comment + 1]).ctx(ctx)?;
-                buf[..len_comment + 1].to_vec()
-            };
-
-            String::from_utf8_lossy(&bytes[..len_comment]).into_owned()
-        };
+        ptr.read_exact(&mut buf[..len_comment + 1]).ctx(ctx)?;
+        let comment = String::from_utf8_lossy(&buf[..len_comment]).into_owned();
 
         let mut array = vec![];
         for _ in 0..array_dim {


### PR DESCRIPTION
Theres another line of code that is copy/paste of this.
should copy it over? even though that path doesnt panic for our app
https://github.com/Simworx/ads-rs/blob/e68fb4319026d80c95d918a255808821f22b7e97/src/symbol.rs#L732

ideally do the same for type names / etc which can also crash it if too long (unlikely though)